### PR TITLE
Slow down game speed by 50%

### DIFF
--- a/enemy.py
+++ b/enemy.py
@@ -4,7 +4,7 @@ import random
 class Enemy:
     def __init__(self, x, y):
         self.position = pygame.Vector2(x, y)
-        self.velocity = pygame.Vector2(random.choice([-1, 1]), random.choice([-1, 1]))
+        self.velocity = pygame.Vector2(random.choice([-0.5, 0.5]), random.choice([-0.5, 0.5]))
         self.rect = pygame.Rect(x, y, 20, 20)  # P2dcf
 
     def update(self):

--- a/game.py
+++ b/game.py
@@ -93,7 +93,7 @@ while running:
     pygame.display.flip()
 
     # Cap the frame rate
-    clock.tick(60)
+    clock.tick(30)
 
 # Quit Pygame
 pygame.quit()

--- a/platform_module.py
+++ b/platform_module.py
@@ -8,7 +8,7 @@ class Platform:
 
     def update(self):
         # Platforms may become unstable over time
-        self.stability -= 0.1
+        self.stability -= 0.05
         if self.stability < 0:
             self.stability = 0
         self.rect.topleft = (self.position.x, self.position.y)

--- a/player.py
+++ b/player.py
@@ -8,17 +8,17 @@ class Player:
         self.rect = pygame.Rect(x, y, 20, 20)
 
     def flap(self):
-        self.velocity.y = -10
+        self.velocity.y = -5
 
     def move_left(self):
-        self.velocity.x = -5
+        self.velocity.x = -2.5
 
     def move_right(self):
-        self.velocity.x = 5
+        self.velocity.x = 2.5
 
     def update(self):
         self.position += self.velocity
-        self.velocity.y += 1  # Gravity effect
+        self.velocity.y += 0.5  # Gravity effect
         self.rect.topleft = (self.position.x, self.position.y)
 
     def draw(self, screen):


### PR DESCRIPTION
Reduce the overall game speed by 50%.

* **Player Movement**
  - Reduce `self.velocity.y` in `flap` method to -5 to slow down the flap speed.
  - Reduce `self.velocity.x` in `move_left` and `move_right` methods to -2.5 to slow down horizontal movement.
  - Reduce gravity effect in `update` method to 0.5 to slow down the falling speed.

* **Enemy Movement**
  - Reduce `self.velocity` in `__init__` method to half of its current value to slow down enemy movement.

* **Platform Stability**
  - Reduce `self.stability` decrement in `update` method to 0.05 to slow down platform instability.

* **Game Speed**
  - Change `clock.tick(60)` to `clock.tick(30)` to slow down the overall game speed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maclarel/Neon-Malfunction/pull/4?shareId=bc0b4519-2e18-4e3f-a3f6-e3cd9243e1c0).