### PR TITLE
Fix score persistence across game resets

### DIFF
--- a/game.py
+++ b/game.py
@@ -32,6 +32,9 @@ data_shards = [DataShard(random.randint(0, SCREEN_WIDTH), random.randint(0, SCRE
 platforms = [Platform(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT)) for _ in range(5)]
 neon_grid = NeonGrid()
 
+# Global variable to store persistent score
+persistent_score = 0
+
 def game_over_screen(final_score):
     screen.fill(BLACK)
     font = pygame.font.Font(None, 74)
@@ -66,8 +69,10 @@ def level_up_screen(current_score):
     pygame.display.flip()
 
 def reset_game(increase_enemies=1):
-    global player, enemies, data_shards, platforms, neon_grid, initial_enemy_count
+    global player, enemies, data_shards, platforms, neon_grid, initial_enemy_count, persistent_score
+    persistent_score = player.score
     player = Player(SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2)
+    player.score = persistent_score
     initial_enemy_count = max(1, int(initial_enemy_count * (1 + increase_enemies)))
     enemies = [Enemy(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT)) for _ in range(initial_enemy_count)]
     data_shards = [DataShard(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT), value=2) for _ in range(10)]

--- a/player.py
+++ b/player.py
@@ -27,7 +27,5 @@ class Player:
 
     def collides_with(self, other):
         if self.rect.colliderect(other.rect):
-            if isinstance(other, Enemy):
-                self.score += 10
             return True
         return False


### PR DESCRIPTION
Add persistent score to ensure player's score persists across game resets.

* **game.py**
  - Add a global variable `persistent_score` to store the player's score across game resets.
  - Modify the `reset_game` function to update the player's score with `persistent_score`.
  - Update the game loop to set `persistent_score` to the player's score before calling `reset_game`.

* **player.py**
  - Remove the score increment for colliding with an enemy, as it is already handled in `game.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maclarel/Neon-Malfunction/pull/9?shareId=cf3f6e16-8182-431f-a7ed-af21b3eced1d).