### PR TITLE
Fix reset game functionality to handle player death and level up

### DIFF
--- a/game.py
+++ b/game.py
@@ -27,6 +27,7 @@ clock = pygame.time.Clock()
 # Create game objects
 player = Player(SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2)
 initial_enemy_count = 5
+original_enemy_count = initial_enemy_count
 enemies = [Enemy(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT)) for _ in range(initial_enemy_count)]
 data_shards = [DataShard(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT), value=2) for _ in range(10)]
 platforms = [Platform(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT)) for _ in range(5)]
@@ -69,14 +70,17 @@ def level_up_screen(current_score):
     pygame.display.flip()
 
 def reset_game(increase_enemies=1, reset_score=False):
-    global player, enemies, data_shards, platforms, neon_grid, initial_enemy_count, persistent_score
+    global player, enemies, data_shards, platforms, neon_grid, initial_enemy_count, persistent_score, original_enemy_count
     if reset_score:
         persistent_score = 0
     else:
         persistent_score = player.score
     player = Player(SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2)
     player.score = persistent_score
-    initial_enemy_count = max(1, int(initial_enemy_count * (1 + increase_enemies)))
+    if increase_enemies == 0:
+        initial_enemy_count = original_enemy_count
+    else:
+        initial_enemy_count = max(1, int(initial_enemy_count * (1 + increase_enemies)))
     enemies = [Enemy(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT)) for _ in range(initial_enemy_count)]
     data_shards = [DataShard(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT), value=2) for _ in range(10)]
     platforms = [Platform(random.randint(0, SCREEN_WIDTH), random.randint(0, SCREEN_HEIGHT)) for _ in range(5)]
@@ -94,7 +98,7 @@ while running:
     if game_over:
         keys = pygame.key.get_pressed()
         if keys[pygame.K_r]:
-            reset_game(reset_score=True)
+            reset_game(increase_enemies=0, reset_score=True)
             game_over = False
         if keys[pygame.K_q]:
             running = False

--- a/game.py
+++ b/game.py
@@ -68,9 +68,12 @@ def level_up_screen(current_score):
 
     pygame.display.flip()
 
-def reset_game(increase_enemies=1):
+def reset_game(increase_enemies=1, reset_score=False):
     global player, enemies, data_shards, platforms, neon_grid, initial_enemy_count, persistent_score
-    persistent_score = player.score
+    if reset_score:
+        persistent_score = 0
+    else:
+        persistent_score = player.score
     player = Player(SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2)
     player.score = persistent_score
     initial_enemy_count = max(1, int(initial_enemy_count * (1 + increase_enemies)))
@@ -91,7 +94,7 @@ while running:
     if game_over:
         keys = pygame.key.get_pressed()
         if keys[pygame.K_r]:
-            reset_game()
+            reset_game(reset_score=True)
             game_over = False
         if keys[pygame.K_q]:
             running = False
@@ -100,7 +103,7 @@ while running:
     if level_up:
         keys = pygame.key.get_pressed()
         if keys[pygame.K_n]:
-            reset_game(increase_enemies=0.2)
+            reset_game(increase_enemies=0.2, reset_score=False)
             level_up = False
         continue
 


### PR DESCRIPTION
Modify the `reset_game` function to accept a `reset_score` parameter.

* **Reset Score Logic**
  - Add logic to reset the score to 0 if `reset_score` is True.
  - Retain the player's score if `reset_score` is False.

* **Game Over Condition**
  - Update the game over condition to call `reset_game` with `reset_score=True`.

* **Level Up Condition**
  - Update the level up condition to call `reset_game` with `reset_score=False`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maclarel/Neon-Malfunction/pull/10?shareId=791c5bc7-17d4-4853-b73a-0eb7962c5825).